### PR TITLE
Export runErrorT explicitly

### DIFF
--- a/Control/Monad/Error.hs
+++ b/Control/Monad/Error.hs
@@ -38,6 +38,7 @@ module Control.Monad.Error (
     Error(..),
     -- * The ErrorT monad transformer
     ErrorT(..),
+    runErrorT,
     mapErrorT,
     module Control.Monad,
     module Control.Monad.Fix,
@@ -51,7 +52,7 @@ module Control.Monad.Error (
 
 import Control.Monad.Error.Class
 import Control.Monad.Trans
-import Control.Monad.Trans.Error (ErrorT(..), mapErrorT)
+import Control.Monad.Trans.Error (ErrorT(..), runErrorT, mapErrorT)
 
 import Control.Monad
 import Control.Monad.Fix


### PR DESCRIPTION
Control.Monad.Error doesn't export runErrorT, because Control.Monad.Trans.Error.ErrorT doesn't export runErrorT using record syntax as of transformers-0.4.0.0.
