### PR TITLE
Changed Identity bind definition

### DIFF
--- a/Control/Monad/Identity.hs
+++ b/Control/Monad/Identity.hs
@@ -13,7 +13,7 @@ Portability :  portable
 [Computation type:] Simple function application.
 
 [Binding strategy:] The bound function is applied to the input value.
-@'Identity' x >>= f == 'Identity' (f x)@
+@'Identity' x >>= f == f x@
 
 [Useful for:] Monads can be derived from monad transformers applied to the
 'Identity' monad.


### PR DESCRIPTION
@edwardk, Shouldn't the defintion of bind for Identity be

``` haskell
Identity x >>= f == f x
```

instead of

``` haskell
Identity x >>= f == Identity (f x)
```

or am I missing something
