### PR TITLE
Add MicroHS to tested-with cabal flag

### DIFF
--- a/mtl.cabal
+++ b/mtl.cabal
@@ -21,7 +21,7 @@ extra-source-files:
   CHANGELOG.markdown
   README.markdown
 
-tested-with: GHC ==8.10 || ==9.2 || ==9.8 || ==9.10 || ==9.12
+tested-with: GHC ==8.10 || ==9.2 || ==9.8 || ==9.10 || ==9.12, MHS ==0.14.15.0
 
 source-repository head
   type: git


### PR DESCRIPTION
Concerning comments at the end of #161 discussion.

Added MicroHaskell with `v0.14.15.0` (from CI) to the `tested-with` cabal flag.

Note: Since Cabal 3.0 set syntax possible for the flag, e.g. ours would be: `tested-with: GHC == {8.10, 9.2, 9.8, 9.10, 9.12, MHS == {0.14.15.0}`

Would that be preferable?

see https://cabal.readthedocs.io/en/3.4/cabal-package.html?highlight=tested#pkg-field-tested-with
